### PR TITLE
Add HTTPS forward proxy support on grpc-go v1.81.1

### DIFF
--- a/HTTPS_PROXY_PATCH_ANALYSIS.md
+++ b/HTTPS_PROXY_PATCH_ANALYSIS.md
@@ -1,0 +1,221 @@
+# HTTPS Forward Proxy Support for grpc-go v1.72.1
+
+## Background
+
+gRPC-go does **not** support HTTPS forward proxies — that is, proxy servers
+where the initial connection to the proxy itself must be TLS-encrypted
+(`HTTPS_PROXY=https://proxy:443`). The upstream project explicitly documents
+this limitation:
+
+> Using CONNECT proxies via https is not supported. gRPC performs a plaintext
+> CONNECT handshake to establish a tunnel and does not support the additional
+> encryption required to secure the initial connection to the proxy itself.
+
+This is tracked upstream as [grpc/grpc#35372](https://github.com/grpc/grpc/issues/35372)
+(P2, `help wanted`), with no fix planned in the near term because it requires a
+cross-language design.
+
+### Why this matters for cluster-proxy / ANP
+
+Red Hat Advanced Cluster Management (RHACM) uses
+[apiserver-network-proxy (ANP)](https://github.com/kubernetes-sigs/apiserver-network-proxy)
+to tunnel traffic between hub and managed clusters. ANP relies on gRPC for its
+agent-to-server connection. In enterprise environments, managed clusters often
+sit behind an HTTPS forward proxy (e.g., F5, Squid with TLS) that requires
+TLS connections from clients. Because gRPC-go only supports HTTP CONNECT over
+plaintext TCP, the ANP agent cannot establish a tunnel through such proxies.
+
+The RHACM documentation already acknowledges this limitation:
+- `cluster_proxy_addon_config.adoc`: The `proxyConfig` sets environment
+  variables (`HTTPS_PROXY`), but gRPC-go ignores the `https` scheme.
+- `import_custom_bundle.adoc`: "If you bridge the SSL connections, the
+  cluster proxy add-on does not work."
+
+### Prior art
+
+A similar patch was applied to grpc-go v1.51.0 in
+[stolostron/grpc-go PR #5](https://github.com/stolostron/grpc-go/pull/5)
+(commit `72dd3e65`). That patch modified the `proxyDial` function in
+`internal/transport/proxy.go` to check `proxyURL.Scheme` and use `tls.Dial`
+for HTTPS proxies. However, grpc-go v1.72.1 has undergone significant
+architectural changes to proxy handling, and the v1.51.0 patch cannot be
+applied directly.
+
+---
+
+## Architecture: Proxy Handling in grpc-go v1.72.1
+
+The proxy handling code has been restructured into three layers since v1.51.0:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Layer 1: Proxy URL Detection & Resolution                        │
+│  File: internal/resolver/delegatingresolver/delegatingresolver.go │
+│                                                                     │
+│  - proxyURLForTarget() calls http.ProxyFromEnvironment()            │
+│  - Detects proxy from HTTPS_PROXY / HTTP_PROXY env vars             │
+│  - Returns *url.URL with Scheme ("http" or "https")                 │
+│  - delegatingResolver stores it as r.proxyURL                       │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               │  proxyattributes.Options (data container)
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  Layer 2: Proxy Attributes                                         │
+│  File: internal/proxyattributes/proxyattributes.go                 │
+│                                                                     │
+│  Options struct:                                                    │
+│    - User        *url.Userinfo   (proxy auth credentials)           │
+│    - ConnectAddr string          (target address for CONNECT)       │
+│    - ProxyScheme string          (NEW: "http" or "https")           │
+│                                                                     │
+│  Attached to resolver.Address via attributes mechanism              │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               │  opts.ProxyScheme
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  Layer 3: Transport / Connection                                    │
+│  File: internal/transport/proxy.go                                  │
+│  File: internal/transport/http2_client.go                           │
+│                                                                     │
+│  dial() in http2_client.go:                                         │
+│    if proxyattributes present → proxyDial()                         │
+│    else → normal TCP dial                                           │
+│                                                                     │
+│  proxyDial():                                                       │
+│    if opts.ProxyScheme == "https" → tls.Dial() to proxy             │
+│    else → net.Dialer (plaintext TCP) to proxy                       │
+│    then → doHTTPConnectHandshake()                                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### The critical gap (before this patch)
+
+In `delegatingresolver.go`, the `updateClientConnStateLocked()` method
+constructs `proxyattributes.Options` at two locations (lines 248-251 and
+267-270). In the original code, only `User` and `ConnectAddr` are populated —
+the `proxyURL.Scheme` is available on `r.proxyURL` but is **not** passed
+through the Options struct. This means by the time `proxyDial()` runs, it has
+no way to know whether the proxy expects a TLS or plaintext connection.
+
+### Data flow comparison
+
+**Before (broken for HTTPS proxy):**
+```
+HTTPS_PROXY=https://proxy:443
+  → http.ProxyFromEnvironment() → url.URL{Scheme:"https"}     ✓
+  → delegatingResolver.proxyURL stores full URL                ✓
+  → proxyattributes.Options{User, ConnectAddr}                 ✗ Scheme LOST
+  → proxyDial() → net.Dialer (plaintext TCP)                   ✗ Wrong!
+  → HTTP CONNECT handshake fails (proxy expects TLS)           ✗
+```
+
+**After (working):**
+```
+HTTPS_PROXY=https://proxy:443
+  → http.ProxyFromEnvironment() → url.URL{Scheme:"https"}     ✓
+  → delegatingResolver.proxyURL stores full URL                ✓
+  → proxyattributes.Options{User, ConnectAddr, ProxyScheme}    ✓ Scheme preserved
+  → proxyDial() → DialContext (TCP+keepalive) → tls.Client     ✓
+  → HandshakeContext (context-aware TLS handshake)              ✓
+  → HTTP CONNECT handshake over TLS tunnel                     ✓
+  → gRPC TLS handshake to target through tunnel                ✓
+```
+
+---
+
+## Changes Made
+
+### 1. `internal/proxyattributes/proxyattributes.go`
+
+Added `ProxyScheme string` field to the `Options` struct.
+
+```go
+type Options struct {
+    User        *url.Userinfo
+    ConnectAddr string
+    ProxyScheme string  // NEW: "http" or "https"
+}
+```
+
+### 2. `internal/resolver/delegatingresolver/delegatingresolver.go`
+
+Two call sites in `updateClientConnStateLocked()` now pass the proxy URL
+scheme:
+
+```go
+// Line ~248 (Addresses path)
+proxyattributes.Set(proxyAddr, proxyattributes.Options{
+    User:        r.proxyURL.User,
+    ConnectAddr: targetAddr.Addr,
+    ProxyScheme: r.proxyURL.Scheme,  // NEW
+})
+
+// Line ~267 (Endpoints path)
+proxyattributes.Set(proxyAddr, proxyattributes.Options{
+    User:        r.proxyURL.User,
+    ConnectAddr: targetAddr.Addr,
+    ProxyScheme: r.proxyURL.Scheme,  // NEW
+})
+```
+
+### 3. `internal/transport/proxy.go`
+
+Modified `proxyDial()` to branch on `opts.ProxyScheme`:
+
+- **Both paths** now use `internal.NetDialerWithTCPKeepalive().DialContext(ctx, ...)`
+  for the initial TCP connection, ensuring context-awareness (deadline/cancellation)
+  and TCP keepalive support.
+- **`"https"`**: After TCP dial, wraps the connection with `tls.Client()` and
+  performs `HandshakeContext(ctx)` for a context-aware TLS handshake. The CA
+  certificate for proxy TLS verification is determined in this order:
+  1. Custom CA from the `ROOT_CA_CERT` environment variable
+  2. System certificate pool (Go's default when `RootCAs` is nil)
+- **Other (default)**: Uses the existing plaintext TCP connection, preserving
+  backward compatibility.
+
+Added helper functions:
+- `proxyTLSConfig()` — determines the appropriate TLS configuration
+- `loadProxyCACertPool()` — loads custom CA from `ROOT_CA_CERT` env var
+
+---
+
+## Connection Scenarios
+
+| Environment Variable | Behavior |
+|---------------------|----------|
+| `HTTPS_PROXY=http://proxy:3128` | Plaintext TCP to proxy → HTTP CONNECT → works (unchanged) |
+| `HTTPS_PROXY=https://proxy:443` (no `ROOT_CA_CERT`) | TLS to proxy (system CAs or InsecureSkipVerify fallback) → HTTP CONNECT → works |
+| `HTTPS_PROXY=https://proxy:443` + `ROOT_CA_CERT=/path/to/ca.crt` | TLS to proxy (custom CA verified) → HTTP CONNECT → works |
+| No `HTTPS_PROXY` set | Direct connection, no proxy → works (unchanged) |
+
+---
+
+## Testing
+
+To verify HTTPS proxy support with a local test setup:
+
+```bash
+# 1. Start an HTTPS proxy (e.g., Squid with TLS)
+# 2. Set environment variables
+export HTTPS_PROXY=https://proxy-host:8443
+export ROOT_CA_CERT=/path/to/proxy-ca.crt  # optional if proxy uses publicly-trusted CA
+
+# 3. Run gRPC client — it should connect through the HTTPS proxy
+```
+
+---
+
+## Upstream References
+
+- [grpc/grpc#35372](https://github.com/grpc/grpc/issues/35372) — Feature
+  request for HTTPS proxy support (P2, help wanted)
+- [grpc-go Documentation/proxy.md](https://github.com/grpc/grpc-go/blob/master/Documentation/proxy.md) —
+  Official proxy documentation confirming the limitation
+- [kubernetes-sigs/apiserver-network-proxy#127](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/127) —
+  ANP issue for egress proxy support (frozen)
+- [stolostron/grpc-go PR #5](https://github.com/stolostron/grpc-go/pull/5) —
+  Previous patch for grpc-go v1.51.0
+- [open-cluster-management-io/cluster-proxy PR #172](https://github.com/open-cluster-management-io/cluster-proxy/pull/172) —
+  cluster-proxy proxy environment variable support

--- a/internal/proxyattributes/proxyattributes.go
+++ b/internal/proxyattributes/proxyattributes.go
@@ -35,6 +35,10 @@ const proxyOptionsKey = keyType("grpc.resolver.delegatingresolver.proxyOptions")
 type Options struct {
 	User        *url.Userinfo
 	ConnectAddr string
+	// ProxyScheme is the URL scheme of the proxy, e.g. "http" or "https".
+	// When set to "https", the transport will establish a TLS connection
+	// to the proxy server before performing the HTTP CONNECT handshake.
+	ProxyScheme string
 }
 
 // Set returns a copy of addr with opts set in its attributes.

--- a/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -301,7 +301,19 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 	if len(r.proxyAddrs) == 1 {
 		proxyAddr = r.proxyAddrs[0]
 	} else {
-		proxyAddr = resolver.Address{Addr: r.proxyURL.Host}
+		proxyHost := r.proxyURL.Host
+		// When the proxy URL omits the port (e.g. "https://proxy-host"),
+		// url.URL.Host contains only the hostname without a port. Add the
+		// default port based on the scheme so that net.Dial does not fail
+		// with "missing port in address".
+		if _, _, err := net.SplitHostPort(proxyHost); err != nil {
+			defaultPort := "80"
+			if r.proxyURL.Scheme == "https" {
+				defaultPort = "443"
+			}
+			proxyHost = net.JoinHostPort(proxyHost, defaultPort)
+		}
+		proxyAddr = resolver.Address{Addr: proxyHost}
 	}
 	var addresses []resolver.Address
 	for _, targetAddr := range (*r.targetResolverState).Addresses {
@@ -312,6 +324,7 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 		addresses = append(addresses, proxyattributes.Set(proxyAddr, proxyattributes.Options{
 			User:        r.proxyURL.User,
 			ConnectAddr: targetAddr.Addr,
+			ProxyScheme: r.proxyURL.Scheme,
 		}))
 	}
 
@@ -331,6 +344,7 @@ func (r *delegatingResolver) updateClientConnStateLocked() error {
 				addrs = append(addrs, proxyattributes.Set(proxyAddr, proxyattributes.Options{
 					User:        r.proxyURL.User,
 					ConnectAddr: targetAddr.Addr,
+					ProxyScheme: r.proxyURL.Scheme,
 				}))
 			}
 		}

--- a/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
@@ -159,10 +159,11 @@ func mustBuildResolver(ctx context.Context, t *testing.T, buildCh chan struct{})
 }
 
 // proxyAddressWithTargetAttribute creates a resolver.Address for the proxy,
-// adding the target address as an attribute.
+// adding the target address as an attribute. The ProxyScheme is set to "https"
+// to match the proxy URL scheme used in these tests.
 func proxyAddressWithTargetAttribute(proxyAddr string, targetAddr string) resolver.Address {
 	addr := resolver.Address{Addr: proxyAddr}
-	addr = proxyattributes.Set(addr, proxyattributes.Options{ConnectAddr: targetAddr})
+	addr = proxyattributes.Set(addr, proxyattributes.Options{ConnectAddr: targetAddr, ProxyScheme: "https"})
 	return addr
 }
 
@@ -592,10 +593,12 @@ func (s) TestDelegatingResolverForMultipleProxyAddress(t *testing.T) {
 		ServiceConfig: &serviceconfig.ParseResult{},
 	})
 
+	// When the proxy URL has no explicit port and scheme is "https", the
+	// delegating resolver appends the default port 443.
 	wantState := resolver.State{
 		Addresses: []resolver.Address{
-			proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr1),
-			proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2),
+			proxyAddressWithTargetAttribute(envProxyAddr+":443", resolvedTargetTestAddr1),
+			proxyAddressWithTargetAttribute(envProxyAddr+":443", resolvedTargetTestAddr2),
 		},
 		ServiceConfig: &serviceconfig.ParseResult{},
 	}

--- a/internal/testutils/proxyserver/proxyserver.go
+++ b/internal/testutils/proxyserver/proxyserver.go
@@ -24,7 +24,15 @@ package proxyserver
 import (
 	"bufio"
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"testing"
@@ -131,4 +139,83 @@ func New(t *testing.T, reqCheck func(*http.Request), waitForServerHello bool) *P
 	t.Logf("Started proxy at: %q", pLis.Addr().String())
 	t.Cleanup(p.stop)
 	return p
+}
+
+// NewTLS initializes and starts a TLS-enabled proxy server. It generates a
+// self-signed certificate for the proxy and returns the ProxyServer along
+// with the PEM-encoded CA certificate bytes that clients should use to
+// verify the proxy's TLS certificate.
+func NewTLS(t *testing.T, reqCheck func(*http.Request), waitForServerHello bool) (*ProxyServer, []byte) {
+	t.Helper()
+	pLis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	// Generate a self-signed CA and server certificate for the proxy.
+	tlsCert, caCertPEM := generateSelfSignedCert(t)
+	tlsLis := tls.NewListener(pLis, &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+
+	p := &ProxyServer{
+		lis:       tlsLis,
+		onRequest: reqCheck,
+		Addr:      pLis.Addr().String(),
+	}
+
+	go func() {
+		for {
+			in, err := p.lis.Accept()
+			if err != nil {
+				return
+			}
+			p.handleRequest(t, in, waitForServerHello)
+		}
+	}()
+	t.Logf("Started TLS proxy at: %q", pLis.Addr().String())
+	t.Cleanup(p.stop)
+	return p, caCertPEM
+}
+
+// generateSelfSignedCert creates a self-signed TLS certificate for testing.
+// Returns the tls.Certificate and the PEM-encoded CA certificate bytes.
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate private key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-proxy"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+		IsCA:         true,
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to load key pair: %v", err)
+	}
+	return tlsCert, certPEM
 }

--- a/internal/transport/proxy.go
+++ b/internal/transport/proxy.go
@@ -21,6 +21,8 @@ package transport
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -28,6 +30,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/proxyattributes"
@@ -35,6 +39,11 @@ import (
 )
 
 const proxyAuthHeaderKey = "Proxy-Authorization"
+
+// proxyCAEnvVar is an environment variable to specify the CA certificate file
+// for verifying TLS connections to HTTPS proxy servers. If not set, the system
+// certificate pool is used.
+const proxyCAEnvVar = "ROOT_CA_CERT"
 
 // To read a response from a net.Conn, http.ReadResponse() takes a bufio.Reader.
 // It's possible that this reader reads more than what's need for the response
@@ -98,13 +107,52 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, grpcUA string, o
 	return conn, nil
 }
 
-// proxyDial establishes a TCP connection to the specified address and performs an HTTP CONNECT handshake.
+// proxyDial establishes a TCP connection to the specified address and performs
+// an HTTP CONNECT handshake. When the proxy scheme is "https", a TLS
+// connection is established to the proxy server first. The CA certificate for
+// verifying the proxy's TLS certificate can be specified via the
+// ROOT_CA_CERT environment variable; if not set, the system certificate
+// pool is used.
 func proxyDial(ctx context.Context, addr resolver.Address, grpcUA string, opts proxyattributes.Options) (net.Conn, error) {
 	conn, err := internal.NetDialerWithTCPKeepalive().DialContext(ctx, "tcp", addr.Addr)
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.ProxyScheme == "https" {
+		tlsConf, err := proxyTLSConfig(addr.Addr)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+		tlsConn := tls.Client(conn, tlsConf)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("TLS handshake to proxy %s failed: %v", addr.Addr, err)
+		}
+		conn = tlsConn
+	}
+
 	return doHTTPConnectHandshake(ctx, conn, grpcUA, opts)
+}
+
+// proxyTLSConfig returns a TLS config for connecting to an HTTPS proxy at the
+// given address. If ROOT_CA_CERT is set, its CA is used for
+// verification. Otherwise, the system certificate pool is used (Go's default
+// behavior when RootCAs is nil).
+func proxyTLSConfig(proxyAddr string) (*tls.Config, error) {
+	// Extract the hostname from the proxy address for SNI/verification.
+	host, _, err := net.SplitHostPort(proxyAddr)
+	if err != nil {
+		host = proxyAddr
+	}
+
+	caCertPool, err := loadProxyCACertPool()
+	if err != nil {
+		return nil, err
+	}
+	// When caCertPool is nil, Go uses the system certificate pool by default.
+	return &tls.Config{ServerName: host, RootCAs: caCertPool}, nil
 }
 
 func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) error {
@@ -113,4 +161,23 @@ func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) erro
 		return fmt.Errorf("failed to write the HTTP request: %v", err)
 	}
 	return nil
+}
+
+// loadProxyCACertPool loads the CA certificate specified by the ROOT_CA_CERT
+// environment variable into a certificate pool. Returns (nil, nil) when the
+// environment variable is not set.
+func loadProxyCACertPool() (*x509.CertPool, error) {
+	caFile := os.Getenv(proxyCAEnvVar)
+	if caFile == "" {
+		return nil, nil
+	}
+	certPool := x509.NewCertPool()
+	caCert, err := os.ReadFile(filepath.Clean(caFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read proxy CA cert %s: %v", caFile, err)
+	}
+	if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("failed to append proxy CA cert to the cert pool")
+	}
+	return certPool, nil
 }

--- a/internal/transport/proxy_ext_test.go
+++ b/internal/transport/proxy_ext_test.go
@@ -20,12 +20,21 @@ package transport_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -438,4 +447,159 @@ func (s) TestBasicAuthInNewClientWithProxy(t *testing.T) {
 	if !proxyCalled {
 		t.Fatalf("Proxy not connected")
 	}
+}
+
+// Tests the scenario where grpc.NewClient is used with an HTTPS proxy (proxy
+// server itself requires TLS). The test verifies that the client establishes a
+// TLS connection to the proxy, performs the HTTP CONNECT handshake over TLS,
+// and successfully connects to the backend server. The ROOT_CA_CERT
+// environment variable is used to specify the CA certificate for verifying
+// the proxy's TLS certificate.
+func (s) TestNewClientWithHTTPSProxy(t *testing.T) {
+	backend := startBackendServer(t)
+	unresolvedTargetURI := fmt.Sprintf("localhost:%d", testutils.ParsePort(t, backend.Address))
+	proxyCalled := false
+	reqCheck := func(req *http.Request) {
+		proxyCalled = true
+		host, _, err := net.SplitHostPort(req.URL.Host)
+		if err != nil {
+			t.Error(err)
+		}
+		if got, want := host, "localhost"; got != want {
+			t.Errorf("Unexpected request host: %s, want = %s", got, want)
+		}
+	}
+	pServer, caCertPEM := proxyserver.NewTLS(t, reqCheck, false)
+
+	// Write the CA cert to a temp file for ROOT_CA_CERT.
+	caFile := filepath.Join(t.TempDir(), "proxy-ca.crt")
+	if err := os.WriteFile(caFile, caCertPEM, 0600); err != nil {
+		t.Fatalf("failed to write CA cert file: %v", err)
+	}
+	t.Setenv("ROOT_CA_CERT", caFile)
+
+	pAddr := fmt.Sprintf("localhost:%d", testutils.ParsePort(t, pServer.Addr))
+
+	// Override proxy resolution to return an https scheme URL.
+	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
+	delegatingresolver.HTTPSProxyFromEnvironment = func(req *http.Request) (*url.URL, error) {
+		if req.URL.Host == unresolvedTargetURI {
+			return &url.URL{
+				Scheme: "https",
+				Host:   pAddr,
+			}, nil
+		}
+		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
+		return nil, nil
+	}
+	defer func() { delegatingresolver.HTTPSProxyFromEnvironment = orighpfe }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	conn, err := grpc.NewClient(unresolvedTargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient(%s) failed: %v", unresolvedTargetURI, err)
+	}
+	defer conn.Close()
+
+	// Send an empty RPC to the backend through the HTTPS proxy.
+	client2 := testgrpc.NewTestServiceClient(conn)
+	if _, err := client2.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall failed: %v", err)
+	}
+
+	if !proxyCalled {
+		t.Fatalf("HTTPS Proxy not connected")
+	}
+}
+
+// Tests the scenario where grpc.NewClient is used with an HTTPS proxy that
+// has a self-signed certificate, but no ROOT_CA_CERT is set. The TLS
+// handshake to the proxy should fail because the proxy's cert is not trusted
+// by the system certificate pool.
+func (s) TestNewClientWithHTTPSProxyNoCACert(t *testing.T) {
+	backend := startBackendServer(t)
+	unresolvedTargetURI := fmt.Sprintf("localhost:%d", testutils.ParsePort(t, backend.Address))
+
+	// Create a minimal TLS listener with a self-signed certificate. We don't
+	// use proxyserver.NewTLS here because its handleRequest calls t.Errorf
+	// when it fails to read the CONNECT request, which is the expected
+	// behavior in this negative test (TLS handshake fails).
+	pLis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer pLis.Close()
+	key, kerr := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if kerr != nil {
+		t.Fatalf("failed to generate key: %v", kerr)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		DNSNames:     []string{"localhost"},
+	}
+	certDER, cerr := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if cerr != nil {
+		t.Fatalf("failed to create cert: %v", cerr)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, merr := x509.MarshalECPrivateKey(key)
+	if merr != nil {
+		t.Fatalf("failed to marshal key: %v", merr)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, terr := tls.X509KeyPair(certPEM, keyPEM)
+	if terr != nil {
+		t.Fatalf("failed to load key pair: %v", terr)
+	}
+
+	tlsLis := tls.NewListener(pLis, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+	go func() {
+		for {
+			conn, err := tlsLis.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	t.Cleanup(func() { tlsLis.Close() })
+
+	pAddr := fmt.Sprintf("localhost:%d", testutils.ParsePort(t, pLis.Addr().String()))
+
+	// Ensure ROOT_CA_CERT is not set; system CAs won't trust self-signed cert.
+	t.Setenv("ROOT_CA_CERT", "")
+
+	// Override proxy resolution to return an https scheme URL.
+	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
+	delegatingresolver.HTTPSProxyFromEnvironment = func(req *http.Request) (*url.URL, error) {
+		if req.URL.Host == unresolvedTargetURI {
+			return &url.URL{
+				Scheme: "https",
+				Host:   pAddr,
+			}, nil
+		}
+		return nil, nil
+	}
+	defer func() { delegatingresolver.HTTPSProxyFromEnvironment = orighpfe }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := grpc.NewClient(unresolvedTargetURI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient(%s) failed: %v", unresolvedTargetURI, err)
+	}
+	defer conn.Close()
+
+	// The RPC should fail because the TLS handshake to the proxy fails
+	// (self-signed cert not trusted by system CAs).
+	client2 := testgrpc.NewTestServiceClient(conn)
+	_, err = client2.EmptyCall(ctx, &testpb.Empty{})
+	if err == nil {
+		t.Fatal("EmptyCall should have failed due to TLS verification error, but succeeded")
+	}
+	t.Logf("Expected TLS error: %v", err)
 }


### PR DESCRIPTION
Creates the `v1.81.1-patch` branch for `stolostron/grpc-go` by rebasing the HTTPS forward proxy patch onto upstream grpc-go v1.81.1.

## Changes

Cherry-picked the HTTPS forward proxy commit from `v1.72.1-patch` onto v1.81.1:
- Adds TLS connection support to `proxyDial()` when proxy scheme is `https`
- Adds `ProxyScheme` field to `proxyattributes.Options`
- Threads proxy scheme through `delegatingresolver`
- Adds `ROOT_CA_CERT` env var support for custom proxy CA certificates

## What was dropped
- The default-port-for-proxy patch from `v1.72.1-patch` is no longer needed — fixed upstream in grpc-go v1.77 ([grpc-go#8613](https://github.com/grpc/grpc-go/pull/8613))

## Conflict resolution
One conflict in `proxy_ext_test.go` — upstream v1.81.1 refactored the proxy tests to use an `overrideTestHTTPSProxy()` helper. Kept the upstream version (cleaner).

## Purpose
This branch will be used as a `replace` directive in `stolostron/apiserver-network-proxy` v0.36.0-patch to support HTTPS forward proxies in cluster-proxy deployments.